### PR TITLE
For #65: Github is clearing notifications.

### DIFF
--- a/src/main/xsl/pipes.xsl
+++ b/src/main/xsl/pipes.xsl
@@ -57,6 +57,9 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <xsl:text> If you want to make changes, just copy the existing one somewhere, delete it and then create a new one.</xsl:text>
     </p>
     <p>
+      <xsl:text>Pipe execution clear all older notifications from Github. This is a Github API limitation, which does not allow to set notifications as read individually.</xsl:text>
+    </p>
+    <p>
       <xsl:text>All supported JSON elements are listed below:</xsl:text>
     </p>
     <p>

--- a/src/main/xsl/pipes.xsl
+++ b/src/main/xsl/pipes.xsl
@@ -63,7 +63,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <xsl:text> Adding a new pipe will cause all Github notifications </xsl:text>
       <xsl:text>that were pending prior to its creation to be cleared.</xsl:text>
       <xsl:text> This is a limitation of the Github API, which does not allow flagging </xsl:text>
-      \<xsl:text>individual messages as being read, forcing us to clear all prior notifications.</xsl:text>
+      <xsl:text>individual messages as being read, forcing us to clear all prior notifications.</xsl:text>
     </p>
     <p>
       <xsl:text>All supported JSON elements are listed below:</xsl:text>

--- a/src/main/xsl/pipes.xsl
+++ b/src/main/xsl/pipes.xsl
@@ -57,7 +57,13 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <xsl:text> If you want to make changes, just copy the existing one somewhere, delete it and then create a new one.</xsl:text>
     </p>
     <p>
-      <xsl:text>Pipe execution clear all older notifications from Github. This is a Github API limitation, which does not allow to set notifications as read individually.</xsl:text>
+      <span style="font-weight: bold">
+        <xsl:text>Warning:</xsl:text>
+      </span>
+      <xsl:text> Adding a new pipe will cause all Github notifications </xsl:text>
+      <xsl:text>that were pending prior to its creation to be cleared.</xsl:text>
+      <xsl:text> This is a limitation of the Github API, which does not allow flagging </xsl:text>
+      \<xsl:text>individual messages as being read, forcing us to clear all prior notifications.</xsl:text>
     </p>
     <p>
       <xsl:text>All supported JSON elements are listed below:</xsl:text>


### PR DESCRIPTION
For #65:
- Added explanation that github API does not allow to set single notification as read and because that all notifications are set as read on pipe execution.